### PR TITLE
add status validation rule and refactor automation scheduling methods

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,18 +49,6 @@ parameters:
 			path: src/Classes/EventManager.php
 
 		-
-			message: '#^Cannot call method hourly\(\) on null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Extension.php
-
-		-
-			message: '#^Result of method Illuminate\\Console\\Scheduling\\CallbackEvent\:\:runInBackground\(\) \(void\) is used\.$#'
-			identifier: method.void
-			count: 2
-			path: src/Extension.php
-
-		-
 			message: '#^Call to an undefined method Igniter\\Admin\\Classes\\BaseWidget\:\:getField\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/Classes/BaseModelAttributesCondition.php
+++ b/src/Classes/BaseModelAttributesCondition.php
@@ -108,7 +108,7 @@ class BaseModelAttributesCondition extends BaseCondition
             return $this->modelAttributes;
         }
 
-        $attributes = array_map(function($info) {
+        $attributes = array_map(function(array|string $info): array {
             if (is_string($info)) {
                 $info = ['label' => $info];
             }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -98,12 +98,12 @@ class Extension extends BaseExtension
         $schedule->call(function(): void {
             // Pull orders created within the last 30days
             EventManager::fireOrderScheduleEvents();
-        })->name('automation-order-schedule')->withoutOverlapping(5)->runInBackground()->hourly();
+        })->name('automation-order-schedule')->withoutOverlapping(5)->hourly();
 
         $schedule->call(function(): void {
             // Pull reservations booked within the last 30days
             EventManager::fireReservationScheduleEvents();
-        })->name('automation-reservation-schedule')->withoutOverlapping(5)->runInBackground()->hourly();
+        })->name('automation-reservation-schedule')->withoutOverlapping(5)->hourly();
 
         $schedule->command('automation:cleanup')->name('Automation Log Cleanup')->daily();
     }

--- a/src/Http/Controllers/Automations.php
+++ b/src/Http/Controllers/Automations.php
@@ -104,6 +104,7 @@ class Automations extends AdminController
         if ($form->getContext() !== 'create') {
             $rules[] = ['name', 'lang:igniter::admin.label_name', 'sometimes|required'];
             $rules[] = ['code', 'lang:igniter.automation::default.label_code', 'sometimes|required'];
+            $rules[] = ['status', 'lang:igniter::admin.label_status', 'sometimes|required|boolean'];
         }
 
         return $this->validatePasses(post($form->arrayName), $rules);

--- a/src/Models/RuleAction.php
+++ b/src/Models/RuleAction.php
@@ -156,7 +156,7 @@ class RuleAction extends Model
         $config = $actionObj->getFieldConfig();
         if ($fields = array_get($config, 'fields')) {
             $fieldAttributes = array_keys($fields);
-            $this->options = array_only($this->options, $fieldAttributes);
+            $this->options = array_merge($this->options ?? [], array_only($this->getAttributes(), $fieldAttributes));
             $this->setRawAttributes(array_except($this->getAttributes(), $fieldAttributes));
         }
     }

--- a/src/Models/RuleAction.php
+++ b/src/Models/RuleAction.php
@@ -97,7 +97,7 @@ class RuleAction extends Model
     }
 
     #[Override]
-    protected function beforeSave()
+    protected function beforeSave(): void
     {
         $this->setCustomData();
     }
@@ -144,10 +144,10 @@ class RuleAction extends Model
 
     protected function loadCustomData()
     {
-        $this->setRawAttributes((array)$this->getAttributes() + (array)$this->options, true);
+        $this->setRawAttributes($this->getAttributes() + $this->options, true);
     }
 
-    protected function setCustomData()
+    protected function setCustomData(): void
     {
         if (!$actionObj = $this->getActionObject()) {
             throw new AutomationException(sprintf('Unable to find action object [%s]', $this->getActionClass()));
@@ -156,7 +156,7 @@ class RuleAction extends Model
         $config = $actionObj->getFieldConfig();
         if ($fields = array_get($config, 'fields')) {
             $fieldAttributes = array_keys($fields);
-            $this->options = array_only($this->getAttributes(), $fieldAttributes);
+            $this->options = array_only($this->options, $fieldAttributes);
             $this->setRawAttributes(array_except($this->getAttributes(), $fieldAttributes));
         }
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,7 +10,6 @@ function callProtectedMethod(object $condition, string $methodName, array $args 
 {
     $reflection = new ReflectionClass($condition);
     $method = $reflection->getMethod($methodName);
-    $method->setAccessible(true);
 
     return $method->invokeArgs($condition, $args);
 }


### PR DESCRIPTION
1. Add status validation rule so that status can be updated when you update an automation
2. Removed runInBackground() method on schedule function because it's not supported on Closure schedule calls.
3. Few refactors