### PR TITLE
Fix Laravel 12 ModelIdentifier compatibility in EventParams job

### DIFF
--- a/src/Jobs/EventParams.php
+++ b/src/Jobs/EventParams.php
@@ -60,4 +60,55 @@ class EventParams implements ShouldQueue
 
         return $result;
     }
+
+    /**
+     * Restore the model from the model identifier instance.
+     *
+     * Overrides the trait method for Laravel 12 compatibility: older framework
+     * builds called $value->getClass(), but Laravel 12 removed that method and
+     * exposes the class name as a public $class property instead.
+     */
+    public function restoreModel($value)
+    {
+        $class = method_exists($value, 'getClass') ? $value->getClass() : $value->class;
+
+        return $this->getQueryForModelRestoration(
+            (new $class)->setConnection($value->connection), $value->id
+        )->useWritePdo()->firstOrFail()->loadMissing($value->relations ?? []);
+    }
+
+    /**
+     * Restore a queueable collection instance.
+     *
+     * Overrides the trait method for Laravel 12 compatibility (same reason as
+     * restoreModel above).
+     */
+    protected function restoreCollection($value)
+    {
+        $class = method_exists($value, 'getClass') ? $value->getClass() : $value->class;
+
+        if (!$class || count($value->id) === 0) {
+            return !is_null($value->collectionClass ?? null)
+                ? new $value->collectionClass
+                : new \Illuminate\Database\Eloquent\Collection;
+        }
+
+        $collection = $this->getQueryForModelRestoration(
+            (new $class)->setConnection($value->connection), $value->id
+        )->useWritePdo()->get();
+
+        if (is_a($class, \Illuminate\Database\Eloquent\Relations\Pivot::class, true) ||
+            in_array(\Illuminate\Database\Eloquent\Relations\Concerns\AsPivot::class, class_uses($class))) {
+            return $collection;
+        }
+
+        $collection = $collection->keyBy->getKey();
+        $collectionClass = get_class($collection);
+
+        return new $collectionClass(
+            (new \Illuminate\Support\Collection($value->id))
+                ->map(fn($id) => $collection[$id] ?? null)
+                ->filter()
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When accepting orders or changing order status, a fatal error occurs:

```
Call to undefined method Illuminate\Contracts\Database\ModelIdentifier::getClass()
at vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php:111
```

Stack trace:
1. `EventParams->handle()`
2. `EventParams->unserializeParams()`
3. `EventParams->getRestoredPropertyValue(ModelIdentifier)`
4. `EventParams->restoreModel(ModelIdentifier)`
5. `SerializesAndRestoresModelIdentifiers::restoreModel()` — calls `$value->getClass()`

## Root Cause

Laravel 12 removed the `getClass()` method from `ModelIdentifier` and made `$class` a direct public property. Older versions of `SerializesAndRestoresModelIdentifiers` called `$value->getClass()`, which no longer exists.

## Fix

Override `restoreModel()` and `restoreCollection()` directly in `EventParams` with a `method_exists()` guard:

```php
$class = method_exists($value, 'getClass') ? $value->getClass() : $value->class;
```

This makes the job compatible with both old and new Laravel without any breaking changes.

## Test Plan

- [ ] Accept an order in the admin panel — no fatal error
- [ ] Change order status — no fatal error
- [ ] Automation rules with Eloquent model params serialize/unserialize correctly